### PR TITLE
Update Git repository URL in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
     stages {
         stage('Clone Repository') {
             steps {
-                git branch: 'main', url: 'https://github.com/ ваш-аккаунт/ваш-репозиторий.git'
+                git branch: 'main', url: 'https://github.com/AleksejIgnatenko/InnoClinic.Offices.API'
             }
         }
 


### PR DESCRIPTION
Changed the repository URL in the 'Clone Repository' stage of the Jenkinsfile from a placeholder to the specific repository for InnoClinic.Offices.API.