### PR TITLE
Update Jenkinsfile to clone 'master' branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
     stages {
         stage('Clone Repository') {
             steps {
-                git branch: 'main', url: 'https://github.com/AleksejIgnatenko/InnoClinic.Offices.API'
+                git branch: 'master', url: 'https://github.com/AleksejIgnatenko/InnoClinic.Offices.API'
             }
         }
 


### PR DESCRIPTION
Modified the Jenkinsfile to remove the 'main' branch reference and replace it with the 'master' branch for the Git repository. This change aligns the pipeline with the current branch structure.